### PR TITLE
feat: add devServer watchOptions to vuesion cfg

### DIFF
--- a/.vuesion/config.json
+++ b/.vuesion/config.json
@@ -25,5 +25,11 @@
   "spa": {
     "appShellRoute": "/",
     "additionalRoutes": ["/form"]
+  },
+  "devServer": {
+    "watchOptions": {
+      "aggregateTimeout": 300,
+      "poll": false
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,17 +2681,17 @@
       }
     },
     "@vuesion/addon-vuex-persist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vuesion/addon-vuex-persist/-/addon-vuex-persist-2.1.2.tgz",
-      "integrity": "sha512-G92FjxKnbtUHkjN+x3M6NRJmG6Q5NMm2OEIOrmk8yRTqZv614bNa8YaoA7Y+zxVwP2jdXyIHqJmfG9Gv3aMDoQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vuesion/addon-vuex-persist/-/addon-vuex-persist-2.2.0.tgz",
+      "integrity": "sha512-TbO5iB+Eubl/rqpbujwgzFiRrr1gjG/zv0SyM2G718sUm+C924F5TJXTEdoB2p4+3rlAfR5yPLVStEtapbLtSQ==",
       "requires": {
         "js-cookie": "^2.2.0"
       }
     },
     "@vuesion/service": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vuesion/service/-/service-2.1.2.tgz",
-      "integrity": "sha512-80iotBDOU5rwPCX9Xu1DbFHTSE8blZ4rOPkYwzVqZ9UYh2PmIxxtAYVrRxl6unF1DKNXgRwOm7soQZmLqPLaEw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vuesion/service/-/service-2.2.0.tgz",
+      "integrity": "sha512-2qlFo+VAnzLWvh5tiP1gbfk3cRS+SOYjLjEVEoyK2MOa51AO4YCqcARJ4cCmIeuvak5JO+lIXXZq2hkNlYPX2A==",
       "dev": true,
       "requires": {
         "@babel/core": "7.4.4",
@@ -11431,9 +11431,9 @@
       "dev": true
     },
     "istanbul-api": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.7.tgz",
-      "integrity": "sha512-LYTOa2UrYFyJ/aSczZi/6lBykVMjCCvUmT64gOe+jPZFy4w6FYfPGqFT2IiQ2BxVHHDOvCD7qrIXb0EOh4uGWw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.6.tgz",
+      "integrity": "sha512-x0Eicp6KsShG1k1rMgBAi/1GgY7kFGEBwQpw3PXGEmu+rBcBNhqU8g2DgY9mlepAsLPzrzrbqSgCGANnki4POA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -11444,7 +11444,7 @@
         "istanbul-lib-instrument": "^3.3.0",
         "istanbul-lib-report": "^2.0.8",
         "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.5",
+        "istanbul-reports": "^2.2.4",
         "js-yaml": "^3.13.1",
         "make-dir": "^2.1.0",
         "minimatch": "^3.0.4",
@@ -11542,9 +11542,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.5.tgz",
-      "integrity": "sha512-ilCSjE6f7elNIRxnSnIhnOpXdf3ryUT7Zkl+TaADItM638SWXjfNW40cujZCIjex4g4DTkzIy9kzwkaLruB50Q==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
+      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
       "dev": true,
       "requires": {
         "handlebars": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "postci": "vuesion parallel \"npm run build\" \"npm run storybook:build\" \"npx vuepress build docs\""
   },
   "dependencies": {
-    "@vuesion/addon-vuex-persist": "^2.1.2",
+    "@vuesion/addon-vuex-persist": "^2.2.0",
     "accept-language": "3.0.18",
     "animejs": "3.0.1",
     "axios": "0.18.0",
@@ -88,7 +88,7 @@
     "@types/node": "10.12.24",
     "@types/serve-favicon": "2.2.30",
     "@vue/test-utils": "1.0.0-beta.28",
-    "@vuesion/service": "^2.1.2",
+    "@vuesion/service": "^2.2.0",
     "axios-mock-adapter": "1.16.0",
     "husky": "2.1.0",
     "identity-obj-proxy": "3.0.0",


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR adds the possibility to configure the watchOptions for the webpack dev-server. 

This is necessary because the current default values are causing trouble on windows machines, but they are like they are because another use-case of developing inside a docker container was solved with the current settings. 

My conclusion is to provide a configuration for it in order to enable both use cases without coming up with an abstraction.

### Is there something controversial in your PR?
not that I know.

### Link to the Issue
no ticket

# Checklist

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [ ] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
