### PR TITLE
fix(vue-slider): remove focus indicator after move end

### DIFF
--- a/src/app/shared/components/VueSlider/VueSlider.spec.ts
+++ b/src/app/shared/components/VueSlider/VueSlider.spec.ts
@@ -79,7 +79,7 @@ describe('VueSlider.vue', () => {
     expect(wrapper.vm.currentSlider).toBe(0);
   });
 
-  test('should remove handlers on moveEnd', () => {
+  test('should remove handlers on moveEnd', (done) => {
     document.removeEventListener = jest.fn();
     const wrapper = mount<any>(VueSlider, {
       localVue,
@@ -93,9 +93,13 @@ describe('VueSlider.vue', () => {
     wrapper.vm.currentSlider = 1;
     wrapper.vm.moveEnd(null, 0);
 
-    expect(document.removeEventListener).toHaveBeenCalledTimes(5);
-    expect(wrapper.vm.currentSlider).toBe(null);
-    expect(wrapper.emitted('change')).toBeTruthy();
+    setTimeout(() => {
+      expect(document.removeEventListener).toHaveBeenCalledTimes(5);
+      expect(wrapper.vm.currentSlider).toBe(null);
+      expect(wrapper.emitted('change')).toBeTruthy();
+
+      done();
+    }, 100);
   });
 
   test('should do nothing on moveEnd if currentSlider is null', () => {

--- a/src/app/shared/components/VueSlider/VueSlider.vue
+++ b/src/app/shared/components/VueSlider/VueSlider.vue
@@ -15,13 +15,13 @@
     </ul>
 
     <div :class="cssClasses">
-      <div :class="$style.progress" :style="{ width: progressWidth, marginLeft: progressLeft }" />
+      <div :class="$style.progress" :style="{ width: progressWidth, marginLeft: progressLeft }"></div>
 
       <button
         :class="handleCssClasses(0)"
         :style="{ left: handleLeftPosition }"
         :disabled="disabled"
-        aria-disabled="false"
+        :aria-disabled="disabled"
         tabindex="0"
         type="button"
         aria-label="left handle"
@@ -29,14 +29,14 @@
         @focus="currentSlider = 0"
         @keydown="onKeyDown"
         @keyup="onKeyUp"
-      />
+      ></button>
 
       <button
         v-if="isMultiRange"
         :class="handleCssClasses(1)"
         :style="{ left: handleRightPosition }"
         :disabled="disabled"
-        aria-disabled="false"
+        :aria-disabled="disabled"
         tabindex="0"
         type="button"
         aria-label="right handle"
@@ -44,7 +44,7 @@
         @focus="currentSlider = 1"
         @keydown="onKeyDown"
         @keyup="onKeyUp"
-      />
+      ></button>
     </div>
   </div>
 </template>
@@ -173,8 +173,11 @@ export default {
       }
 
       this.$emit('change', { values: [this.currentMin, this.currentMax] });
-      this.currentSlider = null;
-      this.unbindEvents();
+
+      setTimeout(() => {
+        this.currentSlider = null;
+        this.unbindEvents();
+      }, 10);
     },
     moving(e: any) {
       const value: number = algorithm.getValue(this.percentageDiff(e), this.min, this.max);


### PR DESCRIPTION
closes #437

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR fixes the issue that the focus indicator is not removed after move end

### Is there something controversial in your PR?
I used a setTimeout to solve the problem, might not be the most elegant solution

### Link to the Issue
#437

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [ ] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
