### PR TITLE
fix(vue-calendar): fix left padding for negative values

### DIFF
--- a/src/app/shared/components/VueCalendar/VueCalendar.spec.ts
+++ b/src/app/shared/components/VueCalendar/VueCalendar.spec.ts
@@ -220,4 +220,22 @@ describe('VueCalendar.vue', () => {
     expect(years.at(1).text()).toBe('1969');
     expect(years.at(years.length - 1).text()).toBe('2069');
   });
+
+  test('should render the right week days if firstDayOdWeek is 1 and the first day of the month is a sunday', () => {
+    const testDate = new Date(2019, 11, 1);
+    const wrapper = mount<any>(VueCalendar, {
+      localVue,
+      i18n,
+      propsData: {
+        today: testDate,
+        firstDayOfWeek: 1,
+      },
+    });
+    const cell = wrapper
+      .find('tbody')
+      .find('tr')
+      .findAll('td')
+      .at(6);
+    expect(cell.text()).toBe('1');
+  });
 });

--- a/src/app/shared/components/VueCalendar/VueCalendar.stories.ts
+++ b/src/app/shared/components/VueCalendar/VueCalendar.stories.ts
@@ -9,7 +9,7 @@ story.add(
   'Default',
   withInfo({})(() => ({
     components: { VueCalendar },
-    template: `<vue-calendar />`,
+    template: `<vue-calendar :firstDayOfWeek="1"/>`,
     i18n,
   })),
 );

--- a/src/app/shared/components/VueCalendar/VueCalendar.vue
+++ b/src/app/shared/components/VueCalendar/VueCalendar.vue
@@ -167,12 +167,14 @@ export default {
     calendar(): IDay[][] {
       let days: number[] = [];
 
-      const paddingLeft = new Date(this.currentYear, this.currentMonth, 1).getDay() - this.firstDayOfWeek;
+      let paddingLeft = new Date(this.currentYear, this.currentMonth, 1).getDay() - this.firstDayOfWeek;
       const daysInMonth = 32 - new Date(this.currentYear, this.currentMonth, 32).getDate();
 
-      if (paddingLeft >= 0) {
-        days = days.concat(Array(paddingLeft).fill(null));
+      if (paddingLeft === -1) {
+        paddingLeft = 6;
       }
+
+      days = days.concat(Array(paddingLeft).fill(null));
 
       for (let i = 0; i < daysInMonth; i++) {
         days.push(i + 1);


### PR DESCRIPTION
closes #471

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR fixes a bug that appeared if the first day of the month is on a Sunday and the first day of the week is set to Monday. This resulted in a negative left padding which is now set to 6 (Sunday) if negative.

### Is there something controversial in your PR?
nope

### Link to the Issue
#471 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [x] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
