### PR TITLE
refactor(prefetch): call App.prefetch first, then AuthGuard

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -9,7 +9,6 @@ import { store } from './store';
 import { router } from './router';
 import { IState } from './state';
 import { i18n } from '@shared/plugins/i18n/i18n';
-import { HttpService } from '@shared/services/HttpService/HttpService';
 import VueCompositionApi from '@vue/composition-api';
 
 Vue.use(VueCompositionApi);
@@ -24,8 +23,6 @@ export interface IApp {
 
 export const createApp = (): IApp => {
   sync(store, router);
-
-  HttpService.store = store;
 
   const app: Vue = new Vue({
     router,

--- a/src/app/router.ts
+++ b/src/app/router.ts
@@ -1,12 +1,13 @@
 import Vue from 'vue';
 import VueRouter, { Route, RouteRecord } from 'vue-router';
 import Meta from 'vue-meta';
+import { Store } from 'vuex';
+import { IState } from '@/app/state';
 import { AppRoutes } from './app/routes';
 import { HomeRoutes } from './home/routes';
 import { CounterRoutes } from './example/counter/routes';
 import { FormRoutes } from './example/form/routes';
 import { DashboardRoutes } from './example/dashboard/routes';
-import { store } from '@/app/store';
 
 Vue.use(VueRouter);
 Vue.use(Meta);
@@ -25,16 +26,16 @@ export const router: VueRouter = new VueRouter({
 
 // example guard
 // TODO remove or adjust in production code
-router.beforeEach((to: Route, from: Route, next: any) => {
-  if (to.matched.some((record: RouteRecord) => record.meta.requiresAuth)) {
+export const AuthGuard = (route: Route, resolve: any, store: Store<IState>) => {
+  if (route.matched.some((record: RouteRecord) => record.meta.requiresAuth)) {
     const isAuthenticated = store.getters['auth/isAuthenticated'];
 
     if (!isAuthenticated) {
-      next({ path: '/', query: { redirect: to.fullPath } });
+      resolve({ path: '/', query: { redirect: route.fullPath } });
     } else {
-      next();
+      resolve();
     }
   } else {
-    next();
+    resolve();
   }
-});
+};

--- a/src/app/shared/services/HttpService/HttpService.ts
+++ b/src/app/shared/services/HttpService/HttpService.ts
@@ -17,14 +17,7 @@ export let HttpService: IHttpService = axios.create();
 export const initHttpService = (store?: Store<IState>, router?: VueRouter) => {
   /* istanbul ignore next */
   HttpService = axios.create({
-    baseURL:
-      (store &&
-        store.state &&
-        store.state.app &&
-        store.state.app.config &&
-        store.state.app.config.api &&
-        store.state.app.config.api.baseUrl) ||
-      '',
+    baseURL: store?.state?.app?.config?.api?.baseUrl || '',
   });
 
   HttpService.store = store;

--- a/src/app/shared/testing/test-utils.ts
+++ b/src/app/shared/testing/test-utils.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
     triggerDocument[event] = cb;
   });
 
-  document.removeEventListener = jest.fn((event, cb) => {
+  document.removeEventListener = jest.fn((event) => {
     delete triggerDocument[event];
   });
 });

--- a/src/server/utils/Logger.ts
+++ b/src/server/utils/Logger.ts
@@ -2,19 +2,6 @@ import * as winston from 'winston';
 
 export const Logger: winston.Logger = winston.createLogger({
   transports: [
-    new winston.transports.File({
-      filename: 'logs/error.log',
-      level: 'error',
-      maxFiles: 5,
-      maxsize: 10485760,
-      format: winston.format.combine(winston.format.splat(), winston.format.json()),
-    }),
-    new winston.transports.File({
-      filename: 'logs/all.log',
-      maxFiles: 5,
-      maxsize: 10485760,
-      format: winston.format.combine(winston.format.splat(), winston.format.json()),
-    }),
     new winston.transports.Console({
       level: 'debug',
       handleExceptions: true,


### PR DESCRIPTION
closes #350

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?
This PR makes the lifecycle of `prefetch` more explicit. It now does fetch global data before the auth-guard is called, which fixes the problem described in #350. (not able to access prefetched data e.g. roles in the auth-guard)

### Is there something controversial in your PR?
This is only explicit for the AuthGuard that comes with vuesion, users could have problems with custom guards. Maybe, we can find a different abstraction in the future

### Link to the Issue
#350 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [ ] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
