### PR TITLE
test(calendar): corrected existing test

### DIFF
--- a/src/app/shared/components/VueCalendar/VueCalendar.spec.ts
+++ b/src/app/shared/components/VueCalendar/VueCalendar.spec.ts
@@ -208,7 +208,7 @@ describe('VueCalendar.vue', () => {
       localVue,
       i18n,
       propsData: {
-        today: new Date(2000, 1, 1),
+        today: new Date(),
       },
     });
 
@@ -217,8 +217,8 @@ describe('VueCalendar.vue', () => {
     const years = wrapper.find(`.year`).findAll('div');
 
     expect(years).toHaveLength(102);
-    expect(years.at(1).text()).toBe('1969');
-    expect(years.at(years.length - 1).text()).toBe('2069');
+    expect(years.at(1).text()).toBe((today.getFullYear() - 50).toString());
+    expect(years.at(years.length - 1).text()).toBe((today.getFullYear() + 50).toString());
   });
 
   test('should render the right week days if firstDayOdWeek is 1 and the first day of the month is a sunday', () => {


### PR DESCRIPTION
changed assertion since VueCalendar's today property always initializes with current runtime date

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: 
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?

after checking out the vuesion project, i faced a failed test. 
The test was providing a hard coded Date for today property but the component always initializes with the current runtime date. I think in this case should the test be updated.

### Is there something controversial in your PR?

i don't think so

# Checklist

### Test Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [x] updated unit test to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [ ] Add Story / Design System Page for a new component introduced by your PR
