### PR TITLE
Fix memory leak related to logging within server-side rendering

### DIFF
--- a/src/server/utils/Logger.ts
+++ b/src/server/utils/Logger.ts
@@ -1,25 +1,3 @@
-import * as winston from 'winston';
+import { createLogger } from '@/server/utils/createLogger';
 
-export const Logger: winston.Logger = winston.createLogger({
-  transports: [
-    new winston.transports.File({
-      filename: 'logs/error.log',
-      level: 'error',
-      maxFiles: 5,
-      maxsize: 10485760,
-      format: winston.format.combine(winston.format.splat(), winston.format.json()),
-    }),
-    new winston.transports.File({
-      filename: 'logs/all.log',
-      maxFiles: 5,
-      maxsize: 10485760,
-      format: winston.format.combine(winston.format.splat(), winston.format.json()),
-    }),
-    new winston.transports.Console({
-      level: 'debug',
-      handleExceptions: true,
-      format: winston.format.combine(winston.format.splat(), winston.format.colorize(), winston.format.simple()),
-    }),
-  ],
-  exitOnError: false,
-});
+export const Logger = createLogger();

--- a/src/server/utils/createLogger.ts
+++ b/src/server/utils/createLogger.ts
@@ -1,0 +1,27 @@
+import * as winston from 'winston';
+
+export const createLogger = () => {
+  return winston.createLogger({
+    transports: [
+      new winston.transports.File({
+        filename: 'logs/error.log',
+        level: 'error',
+        maxFiles: 5,
+        maxsize: 10485760,
+        format: winston.format.combine(winston.format.splat(), winston.format.json()),
+      }),
+      new winston.transports.File({
+        filename: 'logs/all.log',
+        maxFiles: 5,
+        maxsize: 10485760,
+        format: winston.format.combine(winston.format.splat(), winston.format.json()),
+      }),
+      new winston.transports.Console({
+        level: 'debug',
+        handleExceptions: true,
+        format: winston.format.combine(winston.format.splat(), winston.format.colorize(), winston.format.simple()),
+      }),
+    ],
+    exitOnError: false,
+  });
+};


### PR DESCRIPTION
<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?

This fixes a memory leak with SSR. As we're running every request in a new V8 context, a new logger instance is created every time and is not properly cleaned up. We end up with huge amounts of open file handles for the log files and we get a warning from NodeJS about too many event listeners (`MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. Use emitter.setMaxListeners() to increase limi`).

With the proposed change memory consumption is stable.

### Is there something controversial in your PR?

I was also looking into changing  the setting for SSR to not create a new context for every request but then memory consumption went up and up and never down again so it seems we have another leak that is just controlled by freeing up memory because of the separate contexts. Haven't analyzed this, yet, but as it is also recommended by Vue docs to not create new contexts we might want to look into an extensive solution to the problem.

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Change documentation for the code introduced by your PR
- [ ] Add Story / Design System Page for a new component introduced by your PR

<!--
Thanks for contributing!
-->
