### PR TITLE
style(page/index): fix mobile badge styles

### DIFF
--- a/src/components/marketing/ValueProposition/ValueProposition.vue
+++ b/src/components/marketing/ValueProposition/ValueProposition.vue
@@ -327,14 +327,10 @@ const onTabChange = (tab: number) => {
 
   @include mediaMax(tabletLandscape) {
     .valueProp {
-      position: relative;
       max-width: 430px;
-
-      .mobileBadge {
-        position: absolute;
-        left: 0;
-        top: -$space-20;
-      }
+      display: flex;
+      flex-direction: column;
+      align-items: start;
     }
   }
 


### PR DESCRIPTION
The mobile badge on the home page was positioned absolutely, taking it out of the normal document flow. This caused it to visually overlap with the content below, reducing readability and damaging the user experience.

- Removed `position: absolute` from the mobile badge
- Applied `display: flex` to the parent div
- Badge now respects document flow, preventing overlap
- Flex layout prevents unwanted stretching of the badge

This change improves readability and maintains design integrity on mobile devices, particularly on the home page.

Fixes #630

Before 
![Screenshot 2024-06-09 at 9 34 53 AM](https://github.com/vuesion/vuesion/assets/59838143/89010318-32a2-4b21-ad01-6fa186c2fe46)

After
![Screenshot 2024-06-09 at 9 35 33 AM](https://github.com/vuesion/vuesion/assets/59838143/7d6e2e65-53b5-4439-8f27-30220013e791)